### PR TITLE
Fix incorrect split translations

### DIFF
--- a/hsk.json
+++ b/hsk.json
@@ -890,12 +890,10 @@
     "hanzi": "呢",
     "pinyin": "ne",
     "translations": [
-      "particle indicating that a previously asked question is to be applied to the preceding word (\"What about ...?\"",
-      "\"And ...?\")",
+      "particle indicating that a previously asked question is to be applied to the preceding word (\"What about ...?\", \"And ...?\")",
       "particle for inquiring about location (\"Where is ...?\")",
       "particle signaling a pause",
-      "to emphasize the preceding words and allow the listener time to take them on board (\"ok?\"",
-      "\"are you with me?\")",
+      "to emphasize the preceding words and allow the listener time to take them on board (\"ok?\", \"are you with me?\")",
       "(at the end of a declarative sentence) particle indicating continuation of a state or action",
       "particle indicating strong affirmation"
     ]
@@ -922,8 +920,7 @@
     "hanzi": "你",
     "pinyin": "nǐ",
     "translations": [
-      "you (informal",
-      "as opposed to courteous 您)"
+      "you (informal, as opposed to courteous 您)"
     ]
   },
   {
@@ -1740,8 +1737,7 @@
     "translations": [
       "this",
       "these",
-      "(commonly pr.  before a classifier",
-      "esp. in Beijing)"
+      "(commonly pr.  before a classifier, esp. in Beijing)"
     ]
   },
   {
@@ -1776,9 +1772,7 @@
       "to stay",
       "to reside",
       "to stop",
-      "(suffix indicating firmness",
-      "steadiness",
-      "or coming to a halt)"
+      "(suffix indicating firmness, steadiness, or coming to a halt)"
     ]
   },
   {
@@ -1824,8 +1818,7 @@
     "translations": [
       "to sit",
       "to take a seat",
-      "to take (a bus",
-      "airplane etc)",
+      "to take (a bus, airplane etc)",
       "to bear fruit",
       "variant of 座[zuò]"
     ]
@@ -2044,8 +2037,7 @@
     "translations": [
       "next in sequence",
       "second",
-      "the second (day",
-      "time etc)",
+      "the second (day, time etc)",
       "secondary",
       "vice-",
       "sub-",
@@ -2069,8 +2061,7 @@
       "passing through",
       "through (a gap)",
       "past",
-      "ever (followed by negative",
-      "meaning never)",
+      "ever (followed by negative, meaning never)",
       "(formerly pr.  and related to 縱|纵) to follow",
       "to comply with",
       "to obey",
@@ -2873,8 +2864,7 @@
     "hanzi": "您",
     "pinyin": "nín",
     "translations": [
-      "you (courteous",
-      "as opposed to informal 你)"
+      "you (courteous, as opposed to informal 你)"
     ]
   },
   {
@@ -3589,8 +3579,7 @@
       "re-",
       "second",
       "another",
-      "then (after sth",
-      "and not until then)"
+      "then (after sth, and not until then)"
     ]
   },
   {
@@ -3741,11 +3730,8 @@
       "to die (euph.)",
       "from",
       "through",
-      "away (in compound verbs",
-      "such as 撤走)",
-      "to change (shape",
-      "form",
-      "meaning)"
+      "away (in compound verbs, such as 撤走)",
+      "to change (shape, form, meaning)"
     ]
   },
   {
@@ -4993,8 +4979,7 @@
       "簇[cù]",
       "fancy pattern",
       "florid",
-      "to spend (money",
-      "time)"
+      "to spend (money, time)"
     ]
   },
   {
@@ -5121,8 +5106,7 @@
     "pinyin": "jí",
     "translations": [
       "extremely",
-      "pole (geography",
-      "physics)",
+      "pole (geography, physics)",
       "utmost",
       "top"
     ]
@@ -5415,8 +5399,7 @@
     "hanzi": "举行",
     "pinyin": "jǔ xíng",
     "translations": [
-      "to hold (a meeting",
-      "ceremony etc)"
+      "to hold (a meeting, ceremony etc)"
     ]
   },
   {
@@ -5507,10 +5490,7 @@
     "pinyin": "kǒu",
     "translations": [
       "mouth",
-      "classifier for things with mouths (people",
-      "domestic animals",
-      "cannons",
-      "wells etc)",
+      "classifier for things with mouths (people, domestic animals, cannons, wells etc)",
       "classifier for bites or mouthfuls"
     ]
   },
@@ -6385,10 +6365,7 @@
       "item",
       "article",
       "clause (of law or treaty)",
-      "classifier for long thin things (ribbon",
-      "river",
-      "road",
-      "trousers etc)"
+      "classifier for long thin things (ribbon, river, road, trousers etc)"
     ]
   },
   {
@@ -6675,8 +6652,7 @@
     "hanzi": "校长",
     "pinyin": "xiào zhǎng",
     "translations": [
-      "(college",
-      "university) president",
+      "(college, university) president",
       "headmaster",
       "CL:個|个",
       "位",
@@ -6711,8 +6687,7 @@
     "hanzi": "新鲜",
     "pinyin": "xīn xiān",
     "translations": [
-      "fresh (experience",
-      "food etc)",
+      "fresh (experience, food etc)",
       "freshness",
       "novel",
       "uncommon"
@@ -7545,8 +7520,7 @@
     "hanzi": "倍",
     "pinyin": "bèi",
     "translations": [
-      "(two",
-      "three etc) -fold",
+      "(two, three etc) -fold",
       "times (multiplier)",
       "double",
       "to increase or multiply"
@@ -7734,8 +7708,7 @@
     "hanzi": "不管",
     "pinyin": "bù guǎn",
     "translations": [
-      "no matter (what",
-      "how)",
+      "no matter (what, how)",
       "regardless of",
       "no matter"
     ]
@@ -7972,8 +7945,7 @@
     "hanzi": "抽烟",
     "pinyin": "chōu yān",
     "translations": [
-      "to smoke (a cigarette",
-      "tobacco)"
+      "to smoke (a cigarette, tobacco)"
     ]
   },
   {
@@ -8163,9 +8135,7 @@
     "hanzi": "戴",
     "pinyin": "dài",
     "translations": [
-      "to put on or wear (glasses",
-      "hat",
-      "gloves etc)",
+      "to put on or wear (glasses, hat, gloves etc)",
       "to respect",
       "to bear",
       "to support"
@@ -8196,8 +8166,7 @@
     "translations": [
       "instead",
       "to replace",
-      "to substitute (X for Y",
-      "or a number in an algebraic expression)"
+      "to substitute (X for Y, or a number in an algebraic expression)"
     ]
   },
   {
@@ -8413,8 +8382,7 @@
       "to go missing",
       "to reduce",
       "fall (in prices)",
-      "to lose (value",
-      "weight etc)",
+      "to lose (value, weight etc)",
       "to wag",
       "to swing",
       "to turn",
@@ -8976,9 +8944,7 @@
     "hanzi": "干燥",
     "pinyin": "gān zào",
     "translations": [
-      "to dry (of weather",
-      "paint",
-      "cement etc)",
+      "to dry (of weather, paint, cement etc)",
       "desiccation",
       "dull",
       "uninteresting",
@@ -9457,8 +9423,7 @@
       "CL:滴",
       "頭|头",
       "身[shēn]",
-      "to be speechless (out of helplessness",
-      "embarrassment etc) (Internet slang used as an interjection)"
+      "to be speechless (out of helplessness, embarrassment etc) (Internet slang used as an interjection)"
     ]
   },
   {
@@ -10152,8 +10117,7 @@
       "even though",
       "in spite of",
       "unhesitatingly",
-      "do not hesitate (to ask",
-      "complain etc)",
+      "do not hesitate (to ask, complain etc)",
       "(go ahead and do it) without hesitating"
     ]
   },
@@ -10756,8 +10720,7 @@
       "continuously",
       "in succession",
       "including",
-      "(used with 也",
-      "都 etc) even",
+      "(used with 也, 都 etc) even",
       "company (military)"
     ]
   },
@@ -11366,8 +11329,7 @@
     "hanzi": "起来",
     "pinyin": "qi lai",
     "translations": [
-      "(after a verb",
-      "indicates beginning or completeness)"
+      "(after a verb, indicates beginning or completeness)"
     ]
   },
   {
@@ -11831,8 +11793,7 @@
       "deep",
       "late",
       "profound",
-      "dark (of color",
-      "water etc)"
+      "dark (of color, water etc)"
     ]
   },
   {
@@ -12909,8 +12870,7 @@
     "hanzi": "吸引",
     "pinyin": "xī yǐn",
     "translations": [
-      "to attract (interest",
-      "investment etc)",
+      "to attract (interest, investment etc)",
       "CL:個|个[gè]"
     ]
   },
@@ -13281,8 +13241,7 @@
     "hanzi": "呀",
     "pinyin": "ya",
     "translations": [
-      "(particle equivalent to 啊 after a vowel",
-      "expressing surprise or doubt)"
+      "(particle equivalent to 啊 after a vowel, expressing surprise or doubt)"
     ]
   },
   {
@@ -13992,8 +13951,7 @@
       "to sort out",
       "to straighten out",
       "to list systematically",
-      "to collate (data",
-      "files)",
+      "to collate (data, files)",
       "to pack (luggage)"
     ]
   },
@@ -14077,8 +14035,7 @@
     "hanzi": "之",
     "pinyin": "zhī",
     "translations": [
-      "(possessive particle",
-      "literary equivalent of 的)",
+      "(possessive particle, literary equivalent of 的)",
       "him",
       "her",
       "it"
@@ -14589,8 +14546,7 @@
     "hanzi": "唉",
     "pinyin": "āi",
     "translations": [
-      "interjection or grunt of agreement or recognition (e.g. yes",
-      "it's me!)",
+      "interjection or grunt of agreement or recognition (e.g. yes, it's me!)",
       "to sigh"
     ]
   },
@@ -15207,12 +15163,8 @@
     "translations": [
       "third of 10 heavenly stems 十天干",
       "third in order",
-      "letter \"C\" or roman \"III\" in list \"A",
-      "B",
-      "C\"",
-      "or \"I",
-      "II",
-      "III\" etc",
+      "letter \"C\" or roman \"III\" in list \"A, B, C\"",
+      "or \"I, II, III\" etc",
       "propyl"
     ]
   },
@@ -15492,9 +15444,7 @@
     "hanzi": "采取",
     "pinyin": "cǎi qǔ",
     "translations": [
-      "to adopt or carry out (measures",
-      "policies",
-      "course of action)",
+      "to adopt or carry out (measures, policies, course of action)",
       "to take"
     ]
   },
@@ -15924,8 +15874,7 @@
       "to admit",
       "to concede",
       "to recognize",
-      "recognition (diplomatic",
-      "artistic etc)",
+      "recognition (diplomatic, artistic etc)",
       "to acknowledge"
     ]
   },
@@ -16298,9 +16247,7 @@
     "hanzi": "除非",
     "pinyin": "chú fēi",
     "translations": [
-      "only if (...",
-      "or otherwise",
-      "...)",
+      "only if (..., or otherwise, ...)",
       "only when",
       "only in the case that",
       "unless"
@@ -17241,12 +17188,8 @@
     "translations": [
       "fourth of 10 heavenly stems 十天干",
       "fourth in order",
-      "letter \"D\" or roman \"IV\" in list \"A",
-      "B",
-      "C\"",
-      "or \"I",
-      "II",
-      "III\" etc",
+      "letter \"D\" or roman \"IV\" in list \"A, B, C\"",
+      "or \"I, II, III\" etc",
       "butyl",
       "cubes (of food)"
     ]
@@ -17729,8 +17672,7 @@
       "fair and square",
       "direction",
       "side",
-      "party (to a contract",
-      "dispute etc)",
+      "party (to a contract, dispute etc)",
       "place",
       "method",
       "prescription (medicine)",
@@ -19952,8 +19894,7 @@
     "translations": [
       "first of the ten heavenly stems 十天干[shí tiān gān]",
       "(used for an unspecified person or thing)",
-      "first (in a list",
-      "as a party to a contract etc)",
+      "first (in a list, as a party to a contract etc)",
       "armor plating",
       "shell or carapace",
       "(of the fingers or toes) nail",
@@ -20000,8 +19941,7 @@
     "translations": [
       "value",
       "worth",
-      "fig. values (ethical",
-      "cultural etc)",
+      "fig. values (ethical, cultural etc)",
       "CL:個|个[gè]"
     ]
   },
@@ -20011,8 +19951,7 @@
     "hanzi": "驾驶",
     "pinyin": "jià shǐ",
     "translations": [
-      "to pilot (ship",
-      "airplane etc)",
+      "to pilot (ship, airplane etc)",
       "to drive"
     ]
   },
@@ -21546,11 +21485,7 @@
     "translations": [
       "grain",
       "granule",
-      "classifier for small round things (peas",
-      "bullets",
-      "peanuts",
-      "pills",
-      "grains etc)"
+      "classifier for small round things (peas, bullets, peanuts, pills, grains etc)"
     ]
   },
   {
@@ -22023,9 +21958,7 @@
       "nervous",
       "scared",
       "(of currency) to devalue or depreciate",
-      "classifier for Chinese fractional monetary unit ( = 角",
-      "= 1",
-      "10 yuan or 10 fen 分)"
+      "classifier for Chinese fractional monetary unit ( = 角, = 1, 10 yuan or 10 fen 分)"
     ]
   },
   {
@@ -22209,8 +22142,7 @@
     "hanzi": "面积",
     "pinyin": "miàn ji",
     "translations": [
-      "area (of a floor",
-      "piece of land etc)",
+      "area (of a floor, piece of land etc)",
       "surface area",
       "tract of land"
     ]
@@ -22477,8 +22409,7 @@
     "translations": [
       "slow-witted",
       "blockhead",
-      "log (of wood",
-      "timber etc)",
+      "log (of wood, timber etc)",
       "CL:塊|块",
       "根[gēn]"
     ]
@@ -22610,8 +22541,7 @@
       "to miss (sb)",
       "idea",
       "remembrance",
-      "twenty (banker's anti-fraud numeral corresponding to 廿",
-      "20)"
+      "twenty (banker's anti-fraud numeral corresponding to 廿, 20)"
     ]
   },
   {
@@ -22991,8 +22921,7 @@
       "to lean against",
       "to rely on",
       "on the basis of",
-      "no matter (how",
-      "what etc)",
+      "no matter (how, what etc)",
       "proof"
     ]
   },
@@ -23040,9 +22969,7 @@
     "hanzi": "平方",
     "pinyin": "píng fāng",
     "translations": [
-      "square (as in square foot",
-      "square mile",
-      "square root)"
+      "square (as in square foot, square mile, square root)"
     ]
   },
   {
@@ -23524,8 +23451,7 @@
     "hanzi": "清淡",
     "pinyin": "qīng dàn",
     "translations": [
-      "light (of food",
-      "not greasy or strongly flavored)",
+      "light (of food, not greasy or strongly flavored)",
       "insipid",
       "slack (sales)"
     ]
@@ -23874,8 +23800,7 @@
     "pinyin": "rén wù",
     "translations": [
       "person",
-      "character (in a play",
-      "novel etc)",
+      "character (in a play, novel etc)",
       "protagonist",
       "CL:個|个[gè]"
     ]
@@ -25350,8 +25275,7 @@
       "a case",
       "to overlap",
       "to interleave",
-      "bend (of a river or mountain range",
-      "in place names)",
+      "bend (of a river or mountain range, in place names)",
       "harness",
       "classifier for sets",
       "collections",
@@ -25765,8 +25689,7 @@
     "hanzi": "推辞",
     "pinyin": "tuī cí",
     "translations": [
-      "to decline (an appointment",
-      "invitation etc)"
+      "to decline (an appointment, invitation etc)"
     ]
   },
   {
@@ -26178,10 +26101,7 @@
     "pinyin": "wén jù",
     "translations": [
       "stationery",
-      "item of stationery (pen",
-      "pencil",
-      "eraser",
-      "pencil sharpener etc)"
+      "item of stationery (pen, pencil, eraser, pencil sharpener etc)"
     ]
   },
   {
@@ -27448,8 +27368,7 @@
     "translations": [
       "in case (sth happens)",
       "if",
-      "once (sth happens",
-      "then...)",
+      "once (sth happens, then...)",
       "when",
       "in a short time",
       "in one day"
@@ -27533,15 +27452,9 @@
     "translations": [
       "second of 10 heavenly stems 十天干",
       "second in order",
-      "letter \"B\" or roman \"II\" in list \"A",
-      "B",
-      "C\"",
-      "or \"I",
-      "II",
-      "III\" etc",
-      "second party (in legal contract",
-      "usually 乙方",
-      "as opposed to 甲方)",
+      "letter \"B\" or roman \"II\" in list \"A, B, C\"",
+      "or \"I, II, III\" etc",
+      "second party (in legal contract, usually 乙方, as opposed to 甲方)",
       "ethyl",
       "bent",
       "winding",
@@ -27937,8 +27850,7 @@
     "pinyin": "yǔ qí",
     "translations": [
       "rather than...",
-      "與其|与其 A 不如 B (rather than A",
-      "better to B)"
+      "與其|与其 A 不如 B (rather than A, better to B)"
     ]
   },
   {
@@ -28207,13 +28119,11 @@
     "translations": [
       "to take",
       "to borrow",
-      "to pick (flowers",
-      "fruit etc)",
+      "to pick (flowers, fruit etc)",
       "to pluck",
       "to select",
       "to remove",
-      "to take off (glasses",
-      "hat etc)"
+      "to take off (glasses, hat etc)"
     ]
   },
   {
@@ -28225,8 +28135,7 @@
       "to stick",
       "to affix",
       "to adhere",
-      "to paste (as in cut",
-      "copy and paste)",
+      "to paste (as in cut, copy and paste)",
       "Taiwan pr. [nián tiē]",
       "also written 黏貼|黏贴"
     ]
@@ -28284,8 +28193,7 @@
     "hanzi": "涨",
     "pinyin": "zhǎng",
     "translations": [
-      "to rise (of prices",
-      "rivers)"
+      "to rise (of prices, rivers)"
     ]
   },
   {
@@ -28296,9 +28204,7 @@
     "translations": [
       "to grasp (often fig.)",
       "to control",
-      "to seize (initiative",
-      "opportunity",
-      "destiny)",
+      "to seize (initiative, opportunity, destiny)",
       "to master",
       "to know well",
       "to understand sth well and know how to use it",
@@ -28497,8 +28403,7 @@
     "translations": [
       "to solicit",
       "to seek",
-      "to request (opinions",
-      "feedback etc)",
+      "to request (opinions, feedback etc)",
       "to petition"
     ]
   },
@@ -28522,9 +28427,7 @@
       "whole entity",
       "entire body",
       "synthesis",
-      "as a whole (situation",
-      "construction",
-      "team etc)",
+      "as a whole (situation, construction, team etc)",
       "global",
       "macrocosm",
       "integral",
@@ -28718,8 +28621,7 @@
     "hanzi": "制度",
     "pinyin": "zhì dù",
     "translations": [
-      "system (e.g. political",
-      "adminstrative etc)",
+      "system (e.g. political, adminstrative etc)",
       "institution",
       "CL:個|个[gè]"
     ]
@@ -29842,8 +29744,7 @@
       "evil as opposed to the Way of the King 王道",
       "overbearing",
       "tyranny",
-      "(of liquor",
-      "medicine etc) strong",
+      "(of liquor, medicine etc) strong",
       "potent"
     ]
   },
@@ -29939,8 +29840,7 @@
     "translations": [
       "to issue",
       "to proclaim",
-      "to enact (laws",
-      "decrees etc)"
+      "to enact (laws, decrees etc)"
     ]
   },
   {
@@ -30050,8 +29950,7 @@
     "translations": [
       "see 磅秤 scale",
       "platform balance",
-      "pound (unit of weight",
-      "about 454 grams)"
+      "pound (unit of weight, about 454 grams)"
     ]
   },
   {
@@ -30810,8 +30709,7 @@
     "pinyin": "biǎn",
     "translations": [
       "flat",
-      "(old form of character 匾",
-      "horizontal tablet with inscription)"
+      "(old form of character 匾, horizontal tablet with inscription)"
     ]
   },
   {
@@ -31856,8 +31754,7 @@
     "hanzi": "草案",
     "pinyin": "cǎo àn",
     "translations": [
-      "draft (legislation",
-      "proposal etc)"
+      "draft (legislation, proposal etc)"
     ]
   },
   {
@@ -32515,8 +32412,7 @@
     "hanzi": "成本",
     "pinyin": "chéng běn",
     "translations": [
-      "(manufacturing",
-      "production etc) costs"
+      "(manufacturing, production etc) costs"
     ]
   },
   {
@@ -32841,8 +32737,7 @@
       "superposition",
       "an overlap",
       "redundancy",
-      "reduplication (in Chinese grammar",
-      "e.g. 散散步 to have a stroll)"
+      "reduplication (in Chinese grammar, e.g. 散散步 to have a stroll)"
     ]
   },
   {
@@ -33483,8 +33378,7 @@
       "to match",
       "to add",
       "to throw in (resources)",
-      "to take (boat",
-      "train)"
+      "to take (boat, train)"
     ]
   },
   {
@@ -34529,9 +34423,7 @@
     "hanzi": "冻结",
     "pinyin": "dòng jié",
     "translations": [
-      "to freeze (loan",
-      "wage",
-      "price etc)"
+      "to freeze (loan, wage, price etc)"
     ]
   },
   {
@@ -35204,8 +35096,7 @@
     "pinyin": "fā xíng",
     "translations": [
       "to publish",
-      "to issue (stocks",
-      "currency etc)",
+      "to issue (stocks, currency etc)",
       "to release",
       "to distribute (a film)"
     ]
@@ -35769,8 +35660,7 @@
     "hanzi": "分歧",
     "pinyin": "fēn qí",
     "translations": [
-      "difference (of opinion",
-      "position)",
+      "difference (of opinion, position)",
       "bifurcation"
     ]
   },
@@ -35869,9 +35759,7 @@
     "translations": [
       "storm",
       "violent commotion",
-      "fig. crisis (e.g. revolution",
-      "uprising",
-      "financial crisis etc)"
+      "fig. crisis (e.g. revolution, uprising, financial crisis etc)"
     ]
   },
   {
@@ -38860,9 +38748,7 @@
       "motorized",
       "power-driven",
       "adaptable",
-      "flexible (use",
-      "treatment",
-      "timing etc)"
+      "flexible (use, treatment, timing etc)"
     ]
   },
   {
@@ -39769,8 +39655,7 @@
     "hanzi": "见义勇为",
     "pinyin": "jiàn yì yǒng wéi",
     "translations": [
-      "to see what is right and act courageously (idiom",
-      "from Analects); to stand up bravely for the truth",
+      "to see what is right and act courageously (idiom, from Analects); to stand up bravely for the truth",
       "acting heroically in a just cause"
     ]
   },
@@ -41298,8 +41183,7 @@
     "translations": [
       "kernel",
       "granule",
-      "granulated (sugar",
-      "chemical product)"
+      "granulated (sugar, chemical product)"
     ]
   },
   {
@@ -41613,8 +41497,7 @@
     "hanzi": "挎",
     "pinyin": "kuà",
     "translations": [
-      "to carry (esp. slung over the arm",
-      "shoulder or side)"
+      "to carry (esp. slung over the arm, shoulder or side)"
     ]
   },
   {
@@ -43451,8 +43334,7 @@
     "translations": [
       "quota",
       "number of places",
-      "place (in an institution",
-      "a group etc)"
+      "place (in an institution, a group etc)"
     ]
   },
   {
@@ -43860,8 +43742,7 @@
     "hanzi": "年度",
     "pinyin": "nián dù",
     "translations": [
-      "year (e.g. school year",
-      "fiscal year)",
+      "year (e.g. school year, fiscal year)",
       "annual"
     ]
   },
@@ -43968,8 +43849,7 @@
     "pinyin": "nóng hòu",
     "translations": [
       "dense",
-      "thick (fog",
-      "clouds etc)",
+      "thick (fog, clouds etc)",
       "to have a strong interest in",
       "deep",
       "fully saturated (color)"
@@ -44477,8 +44357,7 @@
     "translations": [
       "to float",
       "to hover",
-      "to drift (also fig.",
-      "to lead a wandering life)",
+      "to drift (also fig., to lead a wandering life)",
       "to rove",
       "showy",
       "superficial"
@@ -45027,10 +44906,7 @@
     "hanzi": "启事",
     "pinyin": "qǐ shì",
     "translations": [
-      "announcement (written",
-      "on billboard",
-      "letter",
-      "newspaper or website)",
+      "announcement (written, on billboard, letter, newspaper or website)",
       "to post information",
       "a notice"
     ]
@@ -45831,8 +45707,7 @@
     "pinyin": "qǔ dì",
     "translations": [
       "to ban",
-      "to prohibit (publications",
-      "customs etc)",
+      "to prohibit (publications, customs etc)",
       "to outlaw",
       "to suppress (violators)"
     ]
@@ -46328,8 +46203,7 @@
     "pinyin": "rèn zhòng dào yuǎn",
     "translations": [
       "a heavy load and a long road",
-      "fig. to bear heavy responsibilities through a long struggle (cf Confucian Analects",
-      "8.7)"
+      "fig. to bear heavy responsibilities through a long struggle (cf Confucian Analects, 8.7)"
     ]
   },
   {
@@ -47247,8 +47121,7 @@
       "mistake",
       "to make a mistake",
       "fault",
-      "service fault (in volleyball",
-      "tennis etc)"
+      "service fault (in volleyball, tennis etc)"
     ]
   },
   {
@@ -47270,8 +47143,7 @@
     "translations": [
       "teacher-training",
       "pedagogical",
-      "normal (school",
-      "e.g. Beijing Normal University)"
+      "normal (school, e.g. Beijing Normal University)"
     ]
   },
   {
@@ -47655,8 +47527,7 @@
     "hanzi": "事务",
     "pinyin": "shì wù",
     "translations": [
-      "(political",
-      "economic etc) affairs",
+      "(political, economic etc) affairs",
       "work"
     ]
   },
@@ -47679,8 +47550,7 @@
       "undertaking",
       "project",
       "activity",
-      "(charitable",
-      "political or revolutionary) cause",
+      "(charitable, political or revolutionary) cause",
       "publicly funded institution",
       "enterprise or foundation",
       "career",
@@ -48012,8 +47882,7 @@
       "to play with",
       "to wield",
       "to act (cool etc)",
-      "to display (a skill",
-      "one's temper etc)"
+      "to display (a skill, one's temper etc)"
     ]
   },
   {
@@ -48524,9 +48393,7 @@
     "pinyin": "tān huàn",
     "translations": [
       "paralysis",
-      "be paralyzed (body",
-      "transportation",
-      "etc)"
+      "be paralyzed (body, transportation, etc)"
     ]
   },
   {
@@ -48764,8 +48631,7 @@
     "hanzi": "提炼",
     "pinyin": "tí liàn",
     "translations": [
-      "to extract (ore",
-      "minerals etc)",
+      "to extract (ore, minerals etc)",
       "to refine",
       "to purify",
       "to process"
@@ -49756,9 +49622,7 @@
     "hanzi": "网络",
     "pinyin": "wǎng luò",
     "translations": [
-      "network (computing",
-      "telecommunications",
-      "transport etc)"
+      "network (computing, telecommunications, transport etc)"
     ]
   },
   {
@@ -50322,8 +50186,7 @@
     "hanzi": "武侠",
     "pinyin": "wǔ xiá",
     "translations": [
-      "martial arts chivalry (Chinese literary",
-      "theatrical and cinema genre)",
+      "martial arts chivalry (Chinese literary, theatrical and cinema genre)",
       "knight-errant"
     ]
   },
@@ -50462,8 +50325,7 @@
     "pinyin": "xī qǔ",
     "translations": [
       "to absorb",
-      "to draw (a lesson",
-      "insight etc)",
+      "to draw (a lesson, insight etc)",
       "to assimilate"
     ]
   },
@@ -51970,8 +51832,7 @@
     "hanzi": "巡逻",
     "pinyin": "xún luó",
     "translations": [
-      "to patrol (police",
-      "army or navy)"
+      "to patrol (police, army or navy)"
     ]
   },
   {
@@ -52173,8 +52034,7 @@
     "pinyin": "yán mì",
     "translations": [
       "strict",
-      "tight (organization",
-      "surveillance etc)"
+      "tight (organization, surveillance etc)"
     ]
   },
   {
@@ -53821,9 +53681,7 @@
     "translations": [
       "to be pregnant",
       "to produce offspring",
-      "to nurture (a development",
-      "school of thought",
-      "artwork etc)",
+      "to nurture (a development, school of thought, artwork etc)",
       "fig. replete with (culture etc)"
     ]
   },
@@ -54022,8 +53880,7 @@
     "pinyin": "zāo shòu",
     "translations": [
       "to suffer",
-      "to sustain (loss",
-      "misfortune)"
+      "to sustain (loss, misfortune)"
     ]
   },
   {
@@ -55231,9 +55088,7 @@
       "to check",
       "to bring under control",
       "(in former times) what one is allowed to wear depending on social status",
-      "uniform (army",
-      "party",
-      "school etc)",
+      "uniform (army, party, school etc)",
       "livery (for company employees)",
       "CL:套[tào]"
     ]
@@ -55268,10 +55123,7 @@
     "pinyin": "zhì cí",
     "translations": [
       "to express in words or writing",
-      "to make a speech (esp. short introduction",
-      "vote of thanks",
-      "afterword",
-      "funeral homily etc)",
+      "to make a speech (esp. short introduction, vote of thanks, afterword, funeral homily etc)",
       "to address (an audience)",
       "same as 致詞|致词"
     ]
@@ -55313,9 +55165,7 @@
     "translations": [
       "intelligent",
       "able",
-      "smart (phone",
-      "system",
-      "bomb etc)"
+      "smart (phone, system, bomb etc)"
     ]
   },
   {
@@ -55934,8 +55784,7 @@
     "hanzi": "转让",
     "pinyin": "zhuǎn ràng",
     "translations": [
-      "transfer (technology",
-      "goods etc)",
+      "transfer (technology, goods etc)",
       "conveyancing (property)"
     ]
   },
@@ -56378,8 +56227,7 @@
     "hanzi": "走漏",
     "pinyin": "zǒu lòu",
     "translations": [
-      "to leak (of information",
-      "liquid etc)",
+      "to leak (of information, liquid etc)",
       "to divulge"
     ]
   },

--- a/json/hsk-level-1.json
+++ b/json/hsk-level-1.json
@@ -819,12 +819,10 @@
     "hanzi": "呢",
     "pinyin": "ne",
     "translations": [
-      "particle indicating that a previously asked question is to be applied to the preceding word (\"What about ...?\"",
-      "\"And ...?\")",
+      "particle indicating that a previously asked question is to be applied to the preceding word (\"What about ...?\", \"And ...?\")",
       "particle for inquiring about location (\"Where is ...?\")",
       "particle signaling a pause",
-      "to emphasize the preceding words and allow the listener time to take them on board (\"ok?\"",
-      "\"are you with me?\")",
+      "to emphasize the preceding words and allow the listener time to take them on board (\"ok?\", \"are you with me?\")",
       "(at the end of a declarative sentence) particle indicating continuation of a state or action",
       "particle indicating strong affirmation"
     ]
@@ -849,8 +847,7 @@
     "hanzi": "你",
     "pinyin": "nǐ",
     "translations": [
-      "you (informal",
-      "as opposed to courteous 您)"
+      "you (informal, as opposed to courteous 您)"
     ]
   },
   {
@@ -1598,8 +1595,7 @@
     "translations": [
       "this",
       "these",
-      "(commonly pr.  before a classifier",
-      "esp. in Beijing)"
+      "(commonly pr.  before a classifier, esp. in Beijing)"
     ]
   },
   {
@@ -1631,9 +1627,7 @@
       "to stay",
       "to reside",
       "to stop",
-      "(suffix indicating firmness",
-      "steadiness",
-      "or coming to a halt)"
+      "(suffix indicating firmness, steadiness, or coming to a halt)"
     ]
   },
   {
@@ -1675,8 +1669,7 @@
     "translations": [
       "to sit",
       "to take a seat",
-      "to take (a bus",
-      "airplane etc)",
+      "to take (a bus, airplane etc)",
       "to bear fruit",
       "variant of 座[zuò]"
     ]

--- a/json/hsk-level-2.json
+++ b/json/hsk-level-2.json
@@ -174,8 +174,7 @@
     "translations": [
       "next in sequence",
       "second",
-      "the second (day",
-      "time etc)",
+      "the second (day, time etc)",
       "secondary",
       "vice-",
       "sub-",
@@ -198,8 +197,7 @@
       "passing through",
       "through (a gap)",
       "past",
-      "ever (followed by negative",
-      "meaning never)",
+      "ever (followed by negative, meaning never)",
       "(formerly pr.  and related to 縱|纵) to follow",
       "to comply with",
       "to obey",
@@ -941,8 +939,7 @@
     "hanzi": "您",
     "pinyin": "nín",
     "translations": [
-      "you (courteous",
-      "as opposed to informal 你)"
+      "you (courteous, as opposed to informal 你)"
     ]
   },
   {
@@ -1596,8 +1593,7 @@
       "re-",
       "second",
       "another",
-      "then (after sth",
-      "and not until then)"
+      "then (after sth, and not until then)"
     ]
   },
   {
@@ -1736,11 +1732,8 @@
       "to die (euph.)",
       "from",
       "through",
-      "away (in compound verbs",
-      "such as 撤走)",
-      "to change (shape",
-      "form",
-      "meaning)"
+      "away (in compound verbs, such as 撤走)",
+      "to change (shape, form, meaning)"
     ]
   },
   {

--- a/json/hsk-level-3.json
+++ b/json/hsk-level-3.json
@@ -1124,8 +1124,7 @@
       "簇[cù]",
       "fancy pattern",
       "florid",
-      "to spend (money",
-      "time)"
+      "to spend (money, time)"
     ]
   },
   {
@@ -1241,8 +1240,7 @@
     "pinyin": "jí",
     "translations": [
       "extremely",
-      "pole (geography",
-      "physics)",
+      "pole (geography, physics)",
       "utmost",
       "top"
     ]
@@ -1511,8 +1509,7 @@
     "hanzi": "举行",
     "pinyin": "jǔ xíng",
     "translations": [
-      "to hold (a meeting",
-      "ceremony etc)"
+      "to hold (a meeting, ceremony etc)"
     ]
   },
   {
@@ -1595,10 +1592,7 @@
     "pinyin": "kǒu",
     "translations": [
       "mouth",
-      "classifier for things with mouths (people",
-      "domestic animals",
-      "cannons",
-      "wells etc)",
+      "classifier for things with mouths (people, domestic animals, cannons, wells etc)",
       "classifier for bites or mouthfuls"
     ]
   },
@@ -2397,10 +2391,7 @@
       "item",
       "article",
       "clause (of law or treaty)",
-      "classifier for long thin things (ribbon",
-      "river",
-      "road",
-      "trousers etc)"
+      "classifier for long thin things (ribbon, river, road, trousers etc)"
     ]
   },
   {
@@ -2661,8 +2652,7 @@
     "hanzi": "校长",
     "pinyin": "xiào zhǎng",
     "translations": [
-      "(college",
-      "university) president",
+      "(college, university) president",
       "headmaster",
       "CL:個|个",
       "位",
@@ -2694,8 +2684,7 @@
     "hanzi": "新鲜",
     "pinyin": "xīn xiān",
     "translations": [
-      "fresh (experience",
-      "food etc)",
+      "fresh (experience, food etc)",
       "freshness",
       "novel",
       "uncommon"

--- a/json/hsk-level-4.json
+++ b/json/hsk-level-4.json
@@ -151,8 +151,7 @@
     "hanzi": "倍",
     "pinyin": "bèi",
     "translations": [
-      "(two",
-      "three etc) -fold",
+      "(two, three etc) -fold",
       "times (multiplier)",
       "double",
       "to increase or multiply"
@@ -324,8 +323,7 @@
     "hanzi": "不管",
     "pinyin": "bù guǎn",
     "translations": [
-      "no matter (what",
-      "how)",
+      "no matter (what, how)",
       "regardless of",
       "no matter"
     ]
@@ -541,8 +539,7 @@
     "hanzi": "抽烟",
     "pinyin": "chōu yān",
     "translations": [
-      "to smoke (a cigarette",
-      "tobacco)"
+      "to smoke (a cigarette, tobacco)"
     ]
   },
   {
@@ -714,9 +711,7 @@
     "hanzi": "戴",
     "pinyin": "dài",
     "translations": [
-      "to put on or wear (glasses",
-      "hat",
-      "gloves etc)",
+      "to put on or wear (glasses, hat, gloves etc)",
       "to respect",
       "to bear",
       "to support"
@@ -745,8 +740,7 @@
     "translations": [
       "instead",
       "to replace",
-      "to substitute (X for Y",
-      "or a number in an algebraic expression)"
+      "to substitute (X for Y, or a number in an algebraic expression)"
     ]
   },
   {
@@ -946,8 +940,7 @@
       "to go missing",
       "to reduce",
       "fall (in prices)",
-      "to lose (value",
-      "weight etc)",
+      "to lose (value, weight etc)",
       "to wag",
       "to swing",
       "to turn",
@@ -1466,9 +1459,7 @@
     "hanzi": "干燥",
     "pinyin": "gān zào",
     "translations": [
-      "to dry (of weather",
-      "paint",
-      "cement etc)",
+      "to dry (of weather, paint, cement etc)",
       "desiccation",
       "dull",
       "uninteresting",
@@ -1908,8 +1899,7 @@
       "CL:滴",
       "頭|头",
       "身[shēn]",
-      "to be speechless (out of helplessness",
-      "embarrassment etc) (Internet slang used as an interjection)"
+      "to be speechless (out of helplessness, embarrassment etc) (Internet slang used as an interjection)"
     ]
   },
   {
@@ -2545,8 +2535,7 @@
       "even though",
       "in spite of",
       "unhesitatingly",
-      "do not hesitate (to ask",
-      "complain etc)",
+      "do not hesitate (to ask, complain etc)",
       "(go ahead and do it) without hesitating"
     ]
   },
@@ -3097,8 +3086,7 @@
       "continuously",
       "in succession",
       "including",
-      "(used with 也",
-      "都 etc) even",
+      "(used with 也, 都 etc) even",
       "company (military)"
     ]
   },
@@ -3656,8 +3644,7 @@
     "hanzi": "起来",
     "pinyin": "qi lai",
     "translations": [
-      "(after a verb",
-      "indicates beginning or completeness)"
+      "(after a verb, indicates beginning or completeness)"
     ]
   },
   {
@@ -4081,8 +4068,7 @@
       "deep",
       "late",
       "profound",
-      "dark (of color",
-      "water etc)"
+      "dark (of color, water etc)"
     ]
   },
   {
@@ -5069,8 +5055,7 @@
     "hanzi": "吸引",
     "pinyin": "xī yǐn",
     "translations": [
-      "to attract (interest",
-      "investment etc)",
+      "to attract (interest, investment etc)",
       "CL:個|个[gè]"
     ]
   },
@@ -5410,8 +5395,7 @@
     "hanzi": "呀",
     "pinyin": "ya",
     "translations": [
-      "(particle equivalent to 啊 after a vowel",
-      "expressing surprise or doubt)"
+      "(particle equivalent to 啊 after a vowel, expressing surprise or doubt)"
     ]
   },
   {
@@ -6060,8 +6044,7 @@
       "to sort out",
       "to straighten out",
       "to list systematically",
-      "to collate (data",
-      "files)",
+      "to collate (data, files)",
       "to pack (luggage)"
     ]
   },
@@ -6138,8 +6121,7 @@
     "hanzi": "之",
     "pinyin": "zhī",
     "translations": [
-      "(possessive particle",
-      "literary equivalent of 的)",
+      "(possessive particle, literary equivalent of 的)",
       "him",
       "her",
       "it"

--- a/json/hsk-level-5.json
+++ b/json/hsk-level-5.json
@@ -4,8 +4,7 @@
     "hanzi": "唉",
     "pinyin": "āi",
     "translations": [
-      "interjection or grunt of agreement or recognition (e.g. yes",
-      "it's me!)",
+      "interjection or grunt of agreement or recognition (e.g. yes, it's me!)",
       "to sigh"
     ]
   },
@@ -573,12 +572,8 @@
     "translations": [
       "third of 10 heavenly stems 十天干",
       "third in order",
-      "letter \"C\" or roman \"III\" in list \"A",
-      "B",
-      "C\"",
-      "or \"I",
-      "II",
-      "III\" etc",
+      "letter \"C\" or roman \"III\" in list \"A, B, C\"",
+      "or \"I, II, III\" etc",
       "propyl"
     ]
   },
@@ -834,9 +829,7 @@
     "hanzi": "采取",
     "pinyin": "cǎi qǔ",
     "translations": [
-      "to adopt or carry out (measures",
-      "policies",
-      "course of action)",
+      "to adopt or carry out (measures, policies, course of action)",
       "to take"
     ]
   },
@@ -1230,8 +1223,7 @@
       "to admit",
       "to concede",
       "to recognize",
-      "recognition (diplomatic",
-      "artistic etc)",
+      "recognition (diplomatic, artistic etc)",
       "to acknowledge"
     ]
   },
@@ -1572,9 +1564,7 @@
     "hanzi": "除非",
     "pinyin": "chú fēi",
     "translations": [
-      "only if (...",
-      "or otherwise",
-      "...)",
+      "only if (..., or otherwise, ...)",
       "only when",
       "only in the case that",
       "unless"
@@ -2433,12 +2423,8 @@
     "translations": [
       "fourth of 10 heavenly stems 十天干",
       "fourth in order",
-      "letter \"D\" or roman \"IV\" in list \"A",
-      "B",
-      "C\"",
-      "or \"I",
-      "II",
-      "III\" etc",
+      "letter \"D\" or roman \"IV\" in list \"A, B, C\"",
+      "or \"I, II, III\" etc",
       "butyl",
       "cubes (of food)"
     ]
@@ -2880,8 +2866,7 @@
       "fair and square",
       "direction",
       "side",
-      "party (to a contract",
-      "dispute etc)",
+      "party (to a contract, dispute etc)",
       "place",
       "method",
       "prescription (medicine)",
@@ -4905,8 +4890,7 @@
     "translations": [
       "first of the ten heavenly stems 十天干[shí tiān gān]",
       "(used for an unspecified person or thing)",
-      "first (in a list",
-      "as a party to a contract etc)",
+      "first (in a list, as a party to a contract etc)",
       "armor plating",
       "shell or carapace",
       "(of the fingers or toes) nail",
@@ -4949,8 +4933,7 @@
     "translations": [
       "value",
       "worth",
-      "fig. values (ethical",
-      "cultural etc)",
+      "fig. values (ethical, cultural etc)",
       "CL:個|个[gè]"
     ]
   },
@@ -4959,8 +4942,7 @@
     "hanzi": "驾驶",
     "pinyin": "jià shǐ",
     "translations": [
-      "to pilot (ship",
-      "airplane etc)",
+      "to pilot (ship, airplane etc)",
       "to drive"
     ]
   },
@@ -6359,11 +6341,7 @@
     "translations": [
       "grain",
       "granule",
-      "classifier for small round things (peas",
-      "bullets",
-      "peanuts",
-      "pills",
-      "grains etc)"
+      "classifier for small round things (peas, bullets, peanuts, pills, grains etc)"
     ]
   },
   {
@@ -6795,9 +6773,7 @@
       "nervous",
       "scared",
       "(of currency) to devalue or depreciate",
-      "classifier for Chinese fractional monetary unit ( = 角",
-      "= 1",
-      "10 yuan or 10 fen 分)"
+      "classifier for Chinese fractional monetary unit ( = 角, = 1, 10 yuan or 10 fen 分)"
     ]
   },
   {
@@ -6964,8 +6940,7 @@
     "hanzi": "面积",
     "pinyin": "miàn ji",
     "translations": [
-      "area (of a floor",
-      "piece of land etc)",
+      "area (of a floor, piece of land etc)",
       "surface area",
       "tract of land"
     ]
@@ -7208,8 +7183,7 @@
     "translations": [
       "slow-witted",
       "blockhead",
-      "log (of wood",
-      "timber etc)",
+      "log (of wood, timber etc)",
       "CL:塊|块",
       "根[gēn]"
     ]
@@ -7330,8 +7304,7 @@
       "to miss (sb)",
       "idea",
       "remembrance",
-      "twenty (banker's anti-fraud numeral corresponding to 廿",
-      "20)"
+      "twenty (banker's anti-fraud numeral corresponding to 廿, 20)"
     ]
   },
   {
@@ -7681,8 +7654,7 @@
       "to lean against",
       "to rely on",
       "on the basis of",
-      "no matter (how",
-      "what etc)",
+      "no matter (how, what etc)",
       "proof"
     ]
   },
@@ -7726,9 +7698,7 @@
     "hanzi": "平方",
     "pinyin": "píng fāng",
     "translations": [
-      "square (as in square foot",
-      "square mile",
-      "square root)"
+      "square (as in square foot, square mile, square root)"
     ]
   },
   {
@@ -8168,8 +8138,7 @@
     "hanzi": "清淡",
     "pinyin": "qīng dàn",
     "translations": [
-      "light (of food",
-      "not greasy or strongly flavored)",
+      "light (of food, not greasy or strongly flavored)",
       "insipid",
       "slack (sales)"
     ]
@@ -8489,8 +8458,7 @@
     "pinyin": "rén wù",
     "translations": [
       "person",
-      "character (in a play",
-      "novel etc)",
+      "character (in a play, novel etc)",
       "protagonist",
       "CL:個|个[gè]"
     ]
@@ -9833,8 +9801,7 @@
       "a case",
       "to overlap",
       "to interleave",
-      "bend (of a river or mountain range",
-      "in place names)",
+      "bend (of a river or mountain range, in place names)",
       "harness",
       "classifier for sets",
       "collections",
@@ -10211,8 +10178,7 @@
     "hanzi": "推辞",
     "pinyin": "tuī cí",
     "translations": [
-      "to decline (an appointment",
-      "invitation etc)"
+      "to decline (an appointment, invitation etc)"
     ]
   },
   {
@@ -10587,10 +10553,7 @@
     "pinyin": "wén jù",
     "translations": [
       "stationery",
-      "item of stationery (pen",
-      "pencil",
-      "eraser",
-      "pencil sharpener etc)"
+      "item of stationery (pen, pencil, eraser, pencil sharpener etc)"
     ]
   },
   {
@@ -11745,8 +11708,7 @@
     "translations": [
       "in case (sth happens)",
       "if",
-      "once (sth happens",
-      "then...)",
+      "once (sth happens, then...)",
       "when",
       "in a short time",
       "in one day"
@@ -11823,15 +11785,9 @@
     "translations": [
       "second of 10 heavenly stems 十天干",
       "second in order",
-      "letter \"B\" or roman \"II\" in list \"A",
-      "B",
-      "C\"",
-      "or \"I",
-      "II",
-      "III\" etc",
-      "second party (in legal contract",
-      "usually 乙方",
-      "as opposed to 甲方)",
+      "letter \"B\" or roman \"II\" in list \"A, B, C\"",
+      "or \"I, II, III\" etc",
+      "second party (in legal contract, usually 乙方, as opposed to 甲方)",
       "ethyl",
       "bent",
       "winding",
@@ -12191,8 +12147,7 @@
     "pinyin": "yǔ qí",
     "translations": [
       "rather than...",
-      "與其|与其 A 不如 B (rather than A",
-      "better to B)"
+      "與其|与其 A 不如 B (rather than A, better to B)"
     ]
   },
   {
@@ -12437,13 +12392,11 @@
     "translations": [
       "to take",
       "to borrow",
-      "to pick (flowers",
-      "fruit etc)",
+      "to pick (flowers, fruit etc)",
       "to pluck",
       "to select",
       "to remove",
-      "to take off (glasses",
-      "hat etc)"
+      "to take off (glasses, hat etc)"
     ]
   },
   {
@@ -12454,8 +12407,7 @@
       "to stick",
       "to affix",
       "to adhere",
-      "to paste (as in cut",
-      "copy and paste)",
+      "to paste (as in cut, copy and paste)",
       "Taiwan pr. [nián tiē]",
       "also written 黏貼|黏贴"
     ]
@@ -12508,8 +12460,7 @@
     "hanzi": "涨",
     "pinyin": "zhǎng",
     "translations": [
-      "to rise (of prices",
-      "rivers)"
+      "to rise (of prices, rivers)"
     ]
   },
   {
@@ -12519,9 +12470,7 @@
     "translations": [
       "to grasp (often fig.)",
       "to control",
-      "to seize (initiative",
-      "opportunity",
-      "destiny)",
+      "to seize (initiative, opportunity, destiny)",
       "to master",
       "to know well",
       "to understand sth well and know how to use it",
@@ -12702,8 +12651,7 @@
     "translations": [
       "to solicit",
       "to seek",
-      "to request (opinions",
-      "feedback etc)",
+      "to request (opinions, feedback etc)",
       "to petition"
     ]
   },
@@ -12725,9 +12673,7 @@
       "whole entity",
       "entire body",
       "synthesis",
-      "as a whole (situation",
-      "construction",
-      "team etc)",
+      "as a whole (situation, construction, team etc)",
       "global",
       "macrocosm",
       "integral",
@@ -12905,8 +12851,7 @@
     "hanzi": "制度",
     "pinyin": "zhì dù",
     "translations": [
-      "system (e.g. political",
-      "adminstrative etc)",
+      "system (e.g. political, adminstrative etc)",
       "institution",
       "CL:個|个[gè]"
     ]

--- a/json/hsk-level-6.json
+++ b/json/hsk-level-6.json
@@ -275,8 +275,7 @@
       "evil as opposed to the Way of the King 王道",
       "overbearing",
       "tyranny",
-      "(of liquor",
-      "medicine etc) strong",
+      "(of liquor, medicine etc) strong",
       "potent"
     ]
   },
@@ -363,8 +362,7 @@
     "translations": [
       "to issue",
       "to proclaim",
-      "to enact (laws",
-      "decrees etc)"
+      "to enact (laws, decrees etc)"
     ]
   },
   {
@@ -464,8 +462,7 @@
     "translations": [
       "see 磅秤 scale",
       "platform balance",
-      "pound (unit of weight",
-      "about 454 grams)"
+      "pound (unit of weight, about 454 grams)"
     ]
   },
   {
@@ -1154,8 +1151,7 @@
     "pinyin": "biǎn",
     "translations": [
       "flat",
-      "(old form of character 匾",
-      "horizontal tablet with inscription)"
+      "(old form of character 匾, horizontal tablet with inscription)"
     ]
   },
   {
@@ -2103,8 +2099,7 @@
     "hanzi": "草案",
     "pinyin": "cǎo àn",
     "translations": [
-      "draft (legislation",
-      "proposal etc)"
+      "draft (legislation, proposal etc)"
     ]
   },
   {
@@ -2703,8 +2698,7 @@
     "hanzi": "成本",
     "pinyin": "chéng běn",
     "translations": [
-      "(manufacturing",
-      "production etc) costs"
+      "(manufacturing, production etc) costs"
     ]
   },
   {
@@ -3000,8 +2994,7 @@
       "superposition",
       "an overlap",
       "redundancy",
-      "reduplication (in Chinese grammar",
-      "e.g. 散散步 to have a stroll)"
+      "reduplication (in Chinese grammar, e.g. 散散步 to have a stroll)"
     ]
   },
   {
@@ -3585,8 +3578,7 @@
       "to match",
       "to add",
       "to throw in (resources)",
-      "to take (boat",
-      "train)"
+      "to take (boat, train)"
     ]
   },
   {
@@ -4534,9 +4526,7 @@
     "hanzi": "冻结",
     "pinyin": "dòng jié",
     "translations": [
-      "to freeze (loan",
-      "wage",
-      "price etc)"
+      "to freeze (loan, wage, price etc)"
     ]
   },
   {
@@ -5149,8 +5139,7 @@
     "pinyin": "fā xíng",
     "translations": [
       "to publish",
-      "to issue (stocks",
-      "currency etc)",
+      "to issue (stocks, currency etc)",
       "to release",
       "to distribute (a film)"
     ]
@@ -5660,8 +5649,7 @@
     "hanzi": "分歧",
     "pinyin": "fēn qí",
     "translations": [
-      "difference (of opinion",
-      "position)",
+      "difference (of opinion, position)",
       "bifurcation"
     ]
   },
@@ -5751,9 +5739,7 @@
     "translations": [
       "storm",
       "violent commotion",
-      "fig. crisis (e.g. revolution",
-      "uprising",
-      "financial crisis etc)"
+      "fig. crisis (e.g. revolution, uprising, financial crisis etc)"
     ]
   },
   {
@@ -8467,9 +8453,7 @@
       "motorized",
       "power-driven",
       "adaptable",
-      "flexible (use",
-      "treatment",
-      "timing etc)"
+      "flexible (use, treatment, timing etc)"
     ]
   },
   {
@@ -9293,8 +9277,7 @@
     "hanzi": "见义勇为",
     "pinyin": "jiàn yì yǒng wéi",
     "translations": [
-      "to see what is right and act courageously (idiom",
-      "from Analects); to stand up bravely for the truth",
+      "to see what is right and act courageously (idiom, from Analects); to stand up bravely for the truth",
       "acting heroically in a just cause"
     ]
   },
@@ -10682,8 +10665,7 @@
     "translations": [
       "kernel",
       "granule",
-      "granulated (sugar",
-      "chemical product)"
+      "granulated (sugar, chemical product)"
     ]
   },
   {
@@ -10967,8 +10949,7 @@
     "hanzi": "挎",
     "pinyin": "kuà",
     "translations": [
-      "to carry (esp. slung over the arm",
-      "shoulder or side)"
+      "to carry (esp. slung over the arm, shoulder or side)"
     ]
   },
   {
@@ -12634,8 +12615,7 @@
     "translations": [
       "quota",
       "number of places",
-      "place (in an institution",
-      "a group etc)"
+      "place (in an institution, a group etc)"
     ]
   },
   {
@@ -13006,8 +12986,7 @@
     "hanzi": "年度",
     "pinyin": "nián dù",
     "translations": [
-      "year (e.g. school year",
-      "fiscal year)",
+      "year (e.g. school year, fiscal year)",
       "annual"
     ]
   },
@@ -13104,8 +13083,7 @@
     "pinyin": "nóng hòu",
     "translations": [
       "dense",
-      "thick (fog",
-      "clouds etc)",
+      "thick (fog, clouds etc)",
       "to have a strong interest in",
       "deep",
       "fully saturated (color)"
@@ -13567,8 +13545,7 @@
     "translations": [
       "to float",
       "to hover",
-      "to drift (also fig.",
-      "to lead a wandering life)",
+      "to drift (also fig., to lead a wandering life)",
       "to rove",
       "showy",
       "superficial"
@@ -14066,10 +14043,7 @@
     "hanzi": "启事",
     "pinyin": "qǐ shì",
     "translations": [
-      "announcement (written",
-      "on billboard",
-      "letter",
-      "newspaper or website)",
+      "announcement (written, on billboard, letter, newspaper or website)",
       "to post information",
       "a notice"
     ]
@@ -14794,8 +14768,7 @@
     "pinyin": "qǔ dì",
     "translations": [
       "to ban",
-      "to prohibit (publications",
-      "customs etc)",
+      "to prohibit (publications, customs etc)",
       "to outlaw",
       "to suppress (violators)"
     ]
@@ -15247,8 +15220,7 @@
     "pinyin": "rèn zhòng dào yuǎn",
     "translations": [
       "a heavy load and a long road",
-      "fig. to bear heavy responsibilities through a long struggle (cf Confucian Analects",
-      "8.7)"
+      "fig. to bear heavy responsibilities through a long struggle (cf Confucian Analects, 8.7)"
     ]
   },
   {
@@ -16080,8 +16052,7 @@
       "mistake",
       "to make a mistake",
       "fault",
-      "service fault (in volleyball",
-      "tennis etc)"
+      "service fault (in volleyball, tennis etc)"
     ]
   },
   {
@@ -16101,8 +16072,7 @@
     "translations": [
       "teacher-training",
       "pedagogical",
-      "normal (school",
-      "e.g. Beijing Normal University)"
+      "normal (school, e.g. Beijing Normal University)"
     ]
   },
   {
@@ -16450,8 +16420,7 @@
     "hanzi": "事务",
     "pinyin": "shì wù",
     "translations": [
-      "(political",
-      "economic etc) affairs",
+      "(political, economic etc) affairs",
       "work"
     ]
   },
@@ -16472,8 +16441,7 @@
       "undertaking",
       "project",
       "activity",
-      "(charitable",
-      "political or revolutionary) cause",
+      "(charitable, political or revolutionary) cause",
       "publicly funded institution",
       "enterprise or foundation",
       "career",
@@ -16775,8 +16743,7 @@
       "to play with",
       "to wield",
       "to act (cool etc)",
-      "to display (a skill",
-      "one's temper etc)"
+      "to display (a skill, one's temper etc)"
     ]
   },
   {
@@ -17240,9 +17207,7 @@
     "pinyin": "tān huàn",
     "translations": [
       "paralysis",
-      "be paralyzed (body",
-      "transportation",
-      "etc)"
+      "be paralyzed (body, transportation, etc)"
     ]
   },
   {
@@ -17457,8 +17422,7 @@
     "hanzi": "提炼",
     "pinyin": "tí liàn",
     "translations": [
-      "to extract (ore",
-      "minerals etc)",
+      "to extract (ore, minerals etc)",
       "to refine",
       "to purify",
       "to process"
@@ -18357,9 +18321,7 @@
     "hanzi": "网络",
     "pinyin": "wǎng luò",
     "translations": [
-      "network (computing",
-      "telecommunications",
-      "transport etc)"
+      "network (computing, telecommunications, transport etc)"
     ]
   },
   {
@@ -18869,8 +18831,7 @@
     "hanzi": "武侠",
     "pinyin": "wǔ xiá",
     "translations": [
-      "martial arts chivalry (Chinese literary",
-      "theatrical and cinema genre)",
+      "martial arts chivalry (Chinese literary, theatrical and cinema genre)",
       "knight-errant"
     ]
   },
@@ -18996,8 +18957,7 @@
     "pinyin": "xī qǔ",
     "translations": [
       "to absorb",
-      "to draw (a lesson",
-      "insight etc)",
+      "to draw (a lesson, insight etc)",
       "to assimilate"
     ]
   },
@@ -20363,8 +20323,7 @@
     "hanzi": "巡逻",
     "pinyin": "xún luó",
     "translations": [
-      "to patrol (police",
-      "army or navy)"
+      "to patrol (police, army or navy)"
     ]
   },
   {
@@ -20547,8 +20506,7 @@
     "pinyin": "yán mì",
     "translations": [
       "strict",
-      "tight (organization",
-      "surveillance etc)"
+      "tight (organization, surveillance etc)"
     ]
   },
   {
@@ -22041,9 +21999,7 @@
     "translations": [
       "to be pregnant",
       "to produce offspring",
-      "to nurture (a development",
-      "school of thought",
-      "artwork etc)",
+      "to nurture (a development, school of thought, artwork etc)",
       "fig. replete with (culture etc)"
     ]
   },
@@ -22224,8 +22180,7 @@
     "pinyin": "zāo shòu",
     "translations": [
       "to suffer",
-      "to sustain (loss",
-      "misfortune)"
+      "to sustain (loss, misfortune)"
     ]
   },
   {
@@ -23320,9 +23275,7 @@
       "to check",
       "to bring under control",
       "(in former times) what one is allowed to wear depending on social status",
-      "uniform (army",
-      "party",
-      "school etc)",
+      "uniform (army, party, school etc)",
       "livery (for company employees)",
       "CL:套[tào]"
     ]
@@ -23354,10 +23307,7 @@
     "pinyin": "zhì cí",
     "translations": [
       "to express in words or writing",
-      "to make a speech (esp. short introduction",
-      "vote of thanks",
-      "afterword",
-      "funeral homily etc)",
+      "to make a speech (esp. short introduction, vote of thanks, afterword, funeral homily etc)",
       "to address (an audience)",
       "same as 致詞|致词"
     ]
@@ -23395,9 +23345,7 @@
     "translations": [
       "intelligent",
       "able",
-      "smart (phone",
-      "system",
-      "bomb etc)"
+      "smart (phone, system, bomb etc)"
     ]
   },
   {
@@ -23957,8 +23905,7 @@
     "hanzi": "转让",
     "pinyin": "zhuǎn ràng",
     "translations": [
-      "transfer (technology",
-      "goods etc)",
+      "transfer (technology, goods etc)",
       "conveyancing (property)"
     ]
   },
@@ -24360,8 +24307,7 @@
     "hanzi": "走漏",
     "pinyin": "zǒu lòu",
     "translations": [
-      "to leak (of information",
-      "liquid etc)",
+      "to leak (of information, liquid etc)",
       "to divulge"
     ]
   },


### PR DESCRIPTION
rejoin translation that include quotes and parentheses split by commas

regex for parentheses:
([^\\])"([^"]*\([^\)"]*[^\)\\])",\n\s*"([^\)]*\))
\1"\2,\3

quotes fixed by hand